### PR TITLE
DOC: rm links to python documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: circleci-redirector
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/dev/index.html
+          circleci-jobs: build_docs

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -318,7 +318,6 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/{.major}'.format(sys.version_info), None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org/', None),


### PR DESCRIPTION
@QB3 let's just wait until CI builds the doc, it should be lighter colorwise now 


at the moment all floats, lists, etc are in orange and point to not very useful python doc IMO: 
![image](https://user-images.githubusercontent.com/8993218/111472033-dd3b6c00-8729-11eb-8c68-4031157f27e3.png)

