### PR TITLE
robustify against 0 norm features

### DIFF
--- a/andersoncd/solver.py
+++ b/andersoncd/solver.py
@@ -286,6 +286,8 @@ def _kkt_violation_sparse(
 def _cd_epoch(X, y, w, Xw, datafit, penalty, feats):
     lc = datafit.lipschitz
     for j in feats:
+        if lc[j] == 0.:
+            continue
         Xj = X[:, j]
         old_w_j = w[j]
         w[j] = penalty.prox_1d(
@@ -300,6 +302,8 @@ def _cd_epoch_sparse(
         data, indptr, indices, y, w, Xw, datafit, penalty, feats):
     lc = datafit.lipschitz
     for j in feats:
+        if lc[j] == 0.:
+            continue
         Xj = data[indptr[j]:indptr[j+1]]
         idx_nz = indices[indptr[j]:indptr[j+1]]
 


### PR DESCRIPTION
Something weird is happening: without this, the solver fails when X has a 0 column (which is normal, there is a division by 0)

But such a column should not be selected in the WS, right ?

Reproduce with 
```python
import libsvmdata
import numpy as np
from numpy.linalg import norm
from andersoncd import Lasso
X, y = libsvmdata.fetch_libsvm("rcv1.binary")
alpha_max = norm(X.T @ y, ord=np.inf) / len(y)
clf = Lasso(fit_intercept=False, alpha=alpha_max/10, verbose=1).fit(X, y)
```